### PR TITLE
adds lod to worldgen

### DIFF
--- a/prefabs/chunk.tscn
+++ b/prefabs/chunk.tscn
@@ -1,20 +1,251 @@
-[gd_scene load_steps=4 format=3 uid="uid://bkjhriqj5k5ju"]
+[gd_scene load_steps=11 format=3 uid="uid://cjbhimimbjlq5"]
 
-[sub_resource type="BoxShape3D" id="BoxShape3D_d05e6"]
+[ext_resource type="Script" path="res://scripts/chunk.gd" id="1_eqjvd"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_25gpj"]
 size = Vector3(40, 0.25, 40)
 
-[sub_resource type="BoxMesh" id="BoxMesh_i25a4"]
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_qo2s1"]
+albedo_color = Color(0, 0.237179, 0.0603443, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_vxaw8"]
 size = Vector3(40, 0.25, 40)
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_2704g"]
-albedo_color = Color(0, 0.261208, 0.104913, 1)
+[sub_resource type="BoxMesh" id="BoxMesh_ganvj"]
+size = Vector3(80, 0.25, 80)
 
-[node name="Chunk" type="StaticBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_m0meg"]
+albedo_color = Color(0.372939, 0.339155, 4.81307e-07, 1)
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-shape = SubResource("BoxShape3D_d05e6")
+[sub_resource type="BoxShape3D" id="BoxShape3D_me7qi"]
+size = Vector3(80, 0.25, 80)
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
-mesh = SubResource("BoxMesh_i25a4")
-surface_material_override/0 = SubResource("StandardMaterial3D_2704g")
+[sub_resource type="BoxMesh" id="BoxMesh_4djl8"]
+size = Vector3(160, 0.25, 160)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_s7cju"]
+albedo_color = Color(0.391409, 0.0752441, 2.40654e-08, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_e03f8"]
+size = Vector3(160, 0.25, 160)
+
+[node name="Chunk" type="Node3D" node_paths=PackedStringArray("high_lod", "med_lod", "low_lod")]
+script = ExtResource("1_eqjvd")
+high_lod = NodePath("High")
+med_lod = NodePath("Medium")
+low_lod = NodePath("Low")
+
+[node name="High" type="Node3D" parent="."]
+
+[node name="HighLODChunk" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, -60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk2" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, -60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk2"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk2"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk3" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, -60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk3"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk3"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk4" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, -60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk4"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk4"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk5" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, -20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk5"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk5"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk6" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, -20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk6"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk6"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk7" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, -20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk7"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk7"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk8" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, -20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk8"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk8"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk9" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, 20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk9"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk9"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk10" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, 20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk10"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk10"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk11" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, 20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk11"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk11"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk12" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, 20)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk12"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk12"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk13" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, 60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk13"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk13"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk14" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, 60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk14"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk14"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk15" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, 60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk15"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk15"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="HighLODChunk16" type="StaticBody3D" parent="High"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, 60)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk16"]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="High/HighLODChunk16"]
+shape = SubResource("BoxShape3D_vxaw8")
+
+[node name="Medium" type="Node3D" parent="."]
+
+[node name="MediumLODChunk" type="StaticBody3D" parent="Medium"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -40, 0, -40)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk"]
+mesh = SubResource("BoxMesh_ganvj")
+surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Medium/MediumLODChunk"]
+shape = SubResource("BoxShape3D_me7qi")
+
+[node name="MediumLODChunk2" type="StaticBody3D" parent="Medium"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 40, 0, -40)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk2"]
+mesh = SubResource("BoxMesh_ganvj")
+surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Medium/MediumLODChunk2"]
+shape = SubResource("BoxShape3D_me7qi")
+
+[node name="MediumLODChunk3" type="StaticBody3D" parent="Medium"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -40, 0, 40)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk3"]
+mesh = SubResource("BoxMesh_ganvj")
+surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Medium/MediumLODChunk3"]
+shape = SubResource("BoxShape3D_me7qi")
+
+[node name="MediumLODChunk4" type="StaticBody3D" parent="Medium"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 40, 0, 40)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk4"]
+mesh = SubResource("BoxMesh_ganvj")
+surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Medium/MediumLODChunk4"]
+shape = SubResource("BoxShape3D_me7qi")
+
+[node name="Low" type="Node3D" parent="."]
+
+[node name="LowLODChunk" type="StaticBody3D" parent="Low"]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Low/LowLODChunk"]
+mesh = SubResource("BoxMesh_4djl8")
+surface_material_override/0 = SubResource("StandardMaterial3D_s7cju")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Low/LowLODChunk"]
+shape = SubResource("BoxShape3D_e03f8")

--- a/prefabs/chunk.tscn
+++ b/prefabs/chunk.tscn
@@ -3,42 +3,42 @@
 [ext_resource type="Script" path="res://scripts/chunk.gd" id="1_eqjvd"]
 
 [sub_resource type="BoxMesh" id="BoxMesh_25gpj"]
-size = Vector3(40, 0.25, 40)
+size = Vector3(10, 0.25, 10)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_qo2s1"]
 albedo_color = Color(0, 0.237179, 0.0603443, 1)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_vxaw8"]
-size = Vector3(40, 0.25, 40)
+size = Vector3(10, 0.25, 10)
 
 [sub_resource type="BoxMesh" id="BoxMesh_ganvj"]
-size = Vector3(80, 0.25, 80)
+size = Vector3(20.1, 0.25, 20.1)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_m0meg"]
 albedo_color = Color(0.372939, 0.339155, 4.81307e-07, 1)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_me7qi"]
-size = Vector3(80, 0.25, 80)
+size = Vector3(20.1, 0.25, 20.1)
 
 [sub_resource type="BoxMesh" id="BoxMesh_4djl8"]
-size = Vector3(160, 0.25, 160)
+size = Vector3(40.3, 0.25, 40.3)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_s7cju"]
 albedo_color = Color(0.391409, 0.0752441, 2.40654e-08, 1)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_e03f8"]
-size = Vector3(160, 0.25, 160)
+size = Vector3(40.3, 0.25, 40.3)
 
-[node name="Chunk" type="Node3D" node_paths=PackedStringArray("high_lod", "med_lod", "low_lod")]
+[node name="Chunk" type="Node3D" node_paths=PackedStringArray("_high_lod", "_med_lod", "_low_lod")]
 script = ExtResource("1_eqjvd")
-high_lod = NodePath("High")
-med_lod = NodePath("Medium")
-low_lod = NodePath("Low")
+_high_lod = NodePath("High")
+_med_lod = NodePath("Medium")
+_low_lod = NodePath("Low")
 
 [node name="High" type="Node3D" parent="."]
 
 [node name="HighLODChunk" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, -60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -15.15, 0, -15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -48,7 +48,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk2" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, -60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.05, 0, -15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk2"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -58,7 +58,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk3" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, -60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.05, 0, -15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk3"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -68,7 +68,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk4" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, -60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.15, 0, -15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk4"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -78,7 +78,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk5" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, -20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -15.15, 0, -5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk5"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -88,7 +88,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk6" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, -20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.05, 0, -5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk6"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -98,7 +98,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk7" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, -20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.05, 0, -5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk7"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -108,7 +108,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk8" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, -20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.15, 0, -5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk8"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -118,7 +118,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk9" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, 20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -15.15, 0, 5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk9"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -128,7 +128,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk10" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, 20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.05, 0, 5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk10"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -138,7 +138,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk11" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, 20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.05, 0, 5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk11"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -148,7 +148,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk12" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, 20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.15, 0, 5.05)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk12"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -158,7 +158,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk13" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 0, 60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -15.15, 0, 15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk13"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -168,7 +168,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk14" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, 60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.05, 0, 15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk14"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -178,7 +178,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk15" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, 60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.05, 0, 15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk15"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -188,7 +188,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
 shape = SubResource("BoxShape3D_vxaw8")
 
 [node name="HighLODChunk16" type="StaticBody3D" parent="High"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, 60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.15, 0, 15.15)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="High/HighLODChunk16"]
 mesh = SubResource("BoxMesh_25gpj")
@@ -200,7 +200,7 @@ shape = SubResource("BoxShape3D_vxaw8")
 [node name="Medium" type="Node3D" parent="."]
 
 [node name="MediumLODChunk" type="StaticBody3D" parent="Medium"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -40, 0, -40)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10.1, 0, -10.1)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk"]
 mesh = SubResource("BoxMesh_ganvj")
@@ -210,7 +210,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
 shape = SubResource("BoxShape3D_me7qi")
 
 [node name="MediumLODChunk2" type="StaticBody3D" parent="Medium"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 40, 0, -40)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 10.1, 0, -10.1)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk2"]
 mesh = SubResource("BoxMesh_ganvj")
@@ -220,7 +220,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
 shape = SubResource("BoxShape3D_me7qi")
 
 [node name="MediumLODChunk3" type="StaticBody3D" parent="Medium"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -40, 0, 40)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10.1, 0, 10.1)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk3"]
 mesh = SubResource("BoxMesh_ganvj")
@@ -230,7 +230,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
 shape = SubResource("BoxShape3D_me7qi")
 
 [node name="MediumLODChunk4" type="StaticBody3D" parent="Medium"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 40, 0, 40)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 10.1, 0, 10.1)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Medium/MediumLODChunk4"]
 mesh = SubResource("BoxMesh_ganvj")

--- a/prefabs/chunk_high_lod.tscn
+++ b/prefabs/chunk_high_lod.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=4 format=3 uid="uid://craanbr6pjx02"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_25gpj"]
+size = Vector3(40, 0.25, 40)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_qo2s1"]
+albedo_color = Color(0, 0.237179, 0.0603443, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_vxaw8"]
+size = Vector3(40, 0.25, 40)
+
+[node name="HighLODChunk" type="StaticBody3D"]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_25gpj")
+surface_material_override/0 = SubResource("StandardMaterial3D_qo2s1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape3D_vxaw8")

--- a/prefabs/chunk_low_lod.tscn
+++ b/prefabs/chunk_low_lod.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=4 format=3 uid="uid://dslh1dcn1u7cd"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_4djl8"]
+size = Vector3(160, 0.25, 160)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_s7cju"]
+albedo_color = Color(0.391409, 0.0752441, 2.40654e-08, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_e03f8"]
+size = Vector3(160, 0.25, 160)
+
+[node name="LowLODChunk" type="StaticBody3D"]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_4djl8")
+surface_material_override/0 = SubResource("StandardMaterial3D_s7cju")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape3D_e03f8")

--- a/prefabs/chunk_medium_lod.tscn
+++ b/prefabs/chunk_medium_lod.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=4 format=3 uid="uid://wnewi44saic7"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_ganvj"]
+size = Vector3(80, 0.25, 80)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_m0meg"]
+albedo_color = Color(0.372939, 0.339155, 4.81307e-07, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_me7qi"]
+size = Vector3(80, 0.25, 80)
+
+[node name="MediumLODChunk" type="StaticBody3D"]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_ganvj")
+surface_material_override/0 = SubResource("StandardMaterial3D_m0meg")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape3D_me7qi")

--- a/scenes/root.tscn
+++ b/scenes/root.tscn
@@ -19,11 +19,11 @@ max_follow_distance = 200.0
 
 [node name="World" type="Node3D" parent="."]
 script = ExtResource("4_yaodl")
-world_radius = 4
+world_radius = 20
 chunk_size = 40.4
 chunk_boundary_tolerance = 0.1
-high_lod_distance = 80.0
-medium_lod_distance = 160.0
+high_lod_distance = 120.0
+medium_lod_distance = 240.0
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="World"]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 20, 0)

--- a/scenes/root.tscn
+++ b/scenes/root.tscn
@@ -22,6 +22,8 @@ script = ExtResource("4_yaodl")
 world_radius = 4
 chunk_size = 40.4
 chunk_boundary_tolerance = 0.1
+high_lod_distance = 80.0
+medium_lod_distance = 160.0
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="World"]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 20, 0)

--- a/scenes/root.tscn
+++ b/scenes/root.tscn
@@ -15,12 +15,13 @@ script = ExtResource("2_jbuxh")
 
 [node name="OrbitCamera" parent="Player" instance=ExtResource("4_n1aw2")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
-max_follow_distance = 50.0
+max_follow_distance = 200.0
 
 [node name="World" type="Node3D" parent="."]
 script = ExtResource("4_yaodl")
-world_radius = 10
-chunk_size = 160.1
+world_radius = 4
+chunk_size = 40.4
+chunk_boundary_tolerance = 0.1
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="World"]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 20, 0)

--- a/scenes/root.tscn
+++ b/scenes/root.tscn
@@ -20,8 +20,7 @@ max_follow_distance = 50.0
 [node name="World" type="Node3D" parent="."]
 script = ExtResource("4_yaodl")
 world_radius = 10
-chunk_size = 40.1
-chunk_boundary_tolerance = 0.1
+chunk_size = 160.1
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="World"]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 20, 0)

--- a/scripts/chunk.gd
+++ b/scripts/chunk.gd
@@ -18,10 +18,6 @@ func _ready() -> void:
     remove_child(_med_lod)
     _cur_lod = LOD.LOW
 
-    set_lod(Globals.global_lod)
-
-    Globals.set_lod.connect(set_lod)
-
 func set_lod(new_lod: LOD) -> void:
 
     if new_lod == _cur_lod:

--- a/scripts/chunk.gd
+++ b/scripts/chunk.gd
@@ -11,7 +11,7 @@ enum LOD {
     LOW,
 }
 
-func _init() -> void:
+func _ready() -> void:
     set_lod(LOD.LOW)
 
 func set_lod(lod: LOD) -> void:

--- a/scripts/chunk.gd
+++ b/scripts/chunk.gd
@@ -1,9 +1,11 @@
-extends Node
+extends Node3D
 class_name Chunk
 
-@export var high_lod: Node3D
-@export var med_lod: Node3D
-@export var low_lod: Node3D
+@export var _high_lod: Node3D
+@export var _med_lod: Node3D
+@export var _low_lod: Node3D
+
+var _cur_lod: LOD
 
 enum LOD {
     HIGH,
@@ -12,22 +14,35 @@ enum LOD {
 }
 
 func _ready() -> void:
-    set_lod(LOD.LOW)
+    remove_child(_high_lod)
+    remove_child(_med_lod)
+    _cur_lod = LOD.LOW
 
-func set_lod(lod: LOD) -> void:
-    match lod:
+    set_lod(Globals.global_lod)
 
+    Globals.set_lod.connect(set_lod)
+
+func set_lod(new_lod: LOD) -> void:
+
+    if new_lod == _cur_lod:
+        return
+
+    # Remove current LOD
+    match _cur_lod:
         LOD.HIGH:
-            remove_child(low_lod)
-            remove_child(med_lod)
-            add_child(high_lod)
-
+            remove_child(_high_lod)
         LOD.MEDIUM:
-            remove_child(low_lod)
-            add_child(med_lod)
-            remove_child(high_lod)
-
+            remove_child(_med_lod)
         LOD.LOW:
-            add_child(low_lod)
-            remove_child(med_lod)
-            remove_child(high_lod)
+            remove_child(_low_lod)
+
+    # Add new LOD
+    match new_lod:
+        LOD.HIGH:
+            add_child(_high_lod)
+        LOD.MEDIUM:
+            add_child(_med_lod)
+        LOD.LOW:
+            add_child(_low_lod)
+
+    _cur_lod = new_lod

--- a/scripts/chunk.gd
+++ b/scripts/chunk.gd
@@ -18,6 +18,11 @@ func _ready() -> void:
     remove_child(_med_lod)
     _cur_lod = LOD.LOW
 
+    Globals.player_xz.connect(_on_player_xz)
+
+func _on_player_xz(pos: Vector2) -> void:
+    pass
+
 func set_lod(new_lod: LOD) -> void:
 
     if new_lod == _cur_lod:

--- a/scripts/chunk.gd
+++ b/scripts/chunk.gd
@@ -1,0 +1,33 @@
+extends Node
+class_name Chunk
+
+@export var high_lod: Node3D
+@export var med_lod: Node3D
+@export var low_lod: Node3D
+
+enum LOD {
+    HIGH,
+    MEDIUM,
+    LOW,
+}
+
+func _init() -> void:
+    set_lod(LOD.LOW)
+
+func set_lod(lod: LOD) -> void:
+    match lod:
+
+        LOD.HIGH:
+            remove_child(low_lod)
+            remove_child(med_lod)
+            add_child(high_lod)
+
+        LOD.MEDIUM:
+            remove_child(low_lod)
+            add_child(med_lod)
+            remove_child(high_lod)
+
+        LOD.LOW:
+            add_child(low_lod)
+            remove_child(med_lod)
+            remove_child(high_lod)

--- a/scripts/chunk.gd
+++ b/scripts/chunk.gd
@@ -21,7 +21,14 @@ func _ready() -> void:
     Globals.player_xz.connect(_on_player_xz)
 
 func _on_player_xz(pos: Vector2) -> void:
-    pass
+    var dist_to_player: float = (pos - Vector2(position.x, position.z)).length()
+
+    if (dist_to_player <= Globals.high_lod_distance):
+        set_lod(LOD.HIGH)
+    elif (dist_to_player <= Globals.medium_lod_distance):
+        set_lod(LOD.MEDIUM)
+    else:
+        set_lod(LOD.LOW)
 
 func set_lod(new_lod: LOD) -> void:
 

--- a/scripts/chunk.gd
+++ b/scripts/chunk.gd
@@ -23,12 +23,17 @@ func _ready() -> void:
 func _on_player_xz(pos: Vector2) -> void:
     var dist_to_player: float = (pos - Vector2(position.x, position.z)).length()
 
-    if (dist_to_player <= Globals.high_lod_distance):
+    dist_to_player -= Globals.high_lod_distance
+    if (dist_to_player <= 0):
         set_lod(LOD.HIGH)
-    elif (dist_to_player <= Globals.medium_lod_distance):
+        return
+
+    dist_to_player -= Globals.medium_lod_distance
+    if (dist_to_player <= 0):
         set_lod(LOD.MEDIUM)
-    else:
-        set_lod(LOD.LOW)
+        return
+
+    set_lod(LOD.LOW)
 
 func set_lod(new_lod: LOD) -> void:
 

--- a/scripts/chunk_grid.gd
+++ b/scripts/chunk_grid.gd
@@ -103,7 +103,23 @@ func _delete_row(y: int) -> void:
         _delete_chunk(i, y)
 
 func _on_player_xz(pos: Vector2) -> void:
-    pass
+    var center := Vector2(
+        ((_bounds[RIGHT] - _bounds[LEFT] + 1) / 2.0) * _chunk_size.x + _offset.x,
+        ((_bounds[BOTTOM] - _bounds[TOP] + 1) / 2.0) * _chunk_size.y + _offset.y
+    )
+
+    print(_offset)
+    print(pos, "\t", center)
+
+    #if ((pos.x - center.x) > _chunk_size.x):
+        #_move(Globals.DIRECTION.X_POS)
+    #elif ((pos.x - center.x) < -_chunk_size.x):
+        #_move(Globals.DIRECTION.X_NEG)
+#
+    #if ((pos.y - center.y) > _chunk_size.y):
+        #_move(Globals.DIRECTION.Z_POS)
+    #elif ((pos.y - center.y) < -_chunk_size.y):
+        #_move(Globals.DIRECTION.Z_NEG)
 
 func _move(direction: Globals.DIRECTION) -> void:
     match direction:

--- a/scripts/chunk_grid.gd
+++ b/scripts/chunk_grid.gd
@@ -103,23 +103,21 @@ func _delete_row(y: int) -> void:
         _delete_chunk(i, y)
 
 func _on_player_xz(pos: Vector2) -> void:
+
     var center := Vector2(
-        ((_bounds[RIGHT] - _bounds[LEFT] + 1) / 2.0) * _chunk_size.x + _offset.x,
-        ((_bounds[BOTTOM] - _bounds[TOP] + 1) / 2.0) * _chunk_size.y + _offset.y
+        -((_bounds[RIGHT] + _bounds[LEFT] + 1 - _size.x) / 2) * _chunk_size.x + _offset.x,
+        -((_bounds[BOTTOM] + _bounds[TOP] + 1 - _size.y) / 2) * _chunk_size.y + _offset.y
     )
 
-    print(_offset)
-    print(pos, "\t", center)
+    if (pos.x > center.x + _chunk_size.x):
+        _move(Globals.DIRECTION.X_POS)
+    elif (pos.x < center.x - _chunk_size.x):
+        _move(Globals.DIRECTION.X_NEG)
 
-    #if ((pos.x - center.x) > _chunk_size.x):
-        #_move(Globals.DIRECTION.X_POS)
-    #elif ((pos.x - center.x) < -_chunk_size.x):
-        #_move(Globals.DIRECTION.X_NEG)
-#
-    #if ((pos.y - center.y) > _chunk_size.y):
-        #_move(Globals.DIRECTION.Z_POS)
-    #elif ((pos.y - center.y) < -_chunk_size.y):
-        #_move(Globals.DIRECTION.Z_NEG)
+    if (pos.y > center.y + _chunk_size.y):
+        _move(Globals.DIRECTION.Z_POS)
+    elif (pos.y < center.y - _chunk_size.y):
+        _move(Globals.DIRECTION.Z_NEG)
 
 func _move(direction: Globals.DIRECTION) -> void:
     match direction:

--- a/scripts/chunk_grid.gd
+++ b/scripts/chunk_grid.gd
@@ -46,6 +46,8 @@ func _init(
         for y in _size.y:
             _create_chunk(x, y)
 
+    Globals.player_xz.connect(_on_player_xz)
+
 func _out_of_bounds(x: int, y: int) -> bool:
     if (x < _bounds[LEFT] or x > _bounds[RIGHT]
      or y < _bounds[TOP] or y > _bounds[BOTTOM]):
@@ -100,7 +102,10 @@ func _delete_row(y: int) -> void:
     for i in range(_bounds[LEFT], _bounds[RIGHT] + 1):
         _delete_chunk(i, y)
 
-func move(direction: Globals.DIRECTION) -> void:
+func _on_player_xz(pos: Vector2) -> void:
+    pass
+
+func _move(direction: Globals.DIRECTION) -> void:
     match direction:
 
         Globals.DIRECTION.X_POS:

--- a/scripts/chunk_grid.gd
+++ b/scripts/chunk_grid.gd
@@ -10,7 +10,7 @@ enum {
 const BUFFER_SIZE: int = 1
 var _size: Vector2i
 
-var _array: Array[Node3D] = []
+var _array: Array[Chunk] = []
 var _bounds: Array[int] = []
 var _offset: Vector2
 
@@ -70,7 +70,7 @@ func _create_chunk(x: int, y: int) -> void:
     if (_out_of_bounds(x, y)):
         return
 
-    var chunk: Node3D = _chunk_scene.instantiate()
+    var chunk: Chunk = _chunk_scene.instantiate()
     chunk.translate(_world_pos(x, y))
 
     _array[_wrapped_idx(x, y)] = chunk
@@ -80,7 +80,7 @@ func _delete_chunk(x: int, y: int) -> void:
     if (_out_of_bounds(x, y)):
         return
 
-    var chunk: Node3D = _array[_wrapped_idx(x, y)]
+    var chunk: Chunk = _array[_wrapped_idx(x, y)]
     _parent_node.remove_child(chunk)
     chunk.queue_free()
 

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -16,6 +16,12 @@ static var set_camera_x := Signal(instance._set_camera_x)
 static var set_camera_y := Signal(instance._set_camera_y)
 static var set_camera_dist := Signal(instance._set_camera_dist)
 
+# Player (Private/Instanced)
+signal _player_xz(pos: Vector2)
+
+# Player (Public/Static)
+static var player_xz := Signal(instance._player_xz)
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #   Variables
 
 # World Generation

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -16,12 +16,6 @@ static var set_camera_x := Signal(instance._set_camera_x)
 static var set_camera_y := Signal(instance._set_camera_y)
 static var set_camera_dist := Signal(instance._set_camera_dist)
 
-# World (Private/Instanced)
-signal _entered_new_chunk(direction: DIRECTION)
-
-# World (Public/Static)
-static var entered_new_chunk := Signal(instance._entered_new_chunk)
-
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #   Variables
 
 # World Generation

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -18,11 +18,9 @@ static var set_camera_dist := Signal(instance._set_camera_dist)
 
 # World (Private/Instanced)
 signal _entered_new_chunk(direction: DIRECTION)
-signal _set_lod(lod: Chunk.LOD)
 
 # World (Public/Static)
 static var entered_new_chunk := Signal(instance._entered_new_chunk)
-static var set_lod := Signal(instance._set_lod)
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #   Variables
 
@@ -30,7 +28,6 @@ static var set_lod := Signal(instance._set_lod)
 static var world_radius: int = 0
 static var chunk_size: float = 0
 static var chunk_boundary_tolerance: float = 0
-static var global_lod: Chunk.LOD = Chunk.LOD.HIGH
 
 # Mouse Sensitivity
 const GLOBAL_SENSITIVITY: float = 0.01

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -18,9 +18,11 @@ static var set_camera_dist := Signal(instance._set_camera_dist)
 
 # World (Private/Instanced)
 signal _entered_new_chunk(direction: DIRECTION)
+signal _set_lod(lod: Chunk.LOD)
 
 # World (Public/Static)
 static var entered_new_chunk := Signal(instance._entered_new_chunk)
+static var set_lod := Signal(instance._set_lod)
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #   Variables
 
@@ -28,6 +30,7 @@ static var entered_new_chunk := Signal(instance._entered_new_chunk)
 static var world_radius: int = 0
 static var chunk_size: float = 0
 static var chunk_boundary_tolerance: float = 0
+static var global_lod: Chunk.LOD = Chunk.LOD.HIGH
 
 # Mouse Sensitivity
 const GLOBAL_SENSITIVITY: float = 0.01

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -29,6 +29,10 @@ static var world_radius: int = 0
 static var chunk_size: float = 0
 static var chunk_boundary_tolerance: float = 0
 
+# LOD parameters
+static var high_lod_distance: float = 0
+static var medium_lod_distance: float = 0
+
 # Mouse Sensitivity
 const GLOBAL_SENSITIVITY: float = 0.01
 const X_SENSITIVITY: float = 0.9 * GLOBAL_SENSITIVITY

--- a/scripts/input_controller.gd
+++ b/scripts/input_controller.gd
@@ -22,3 +22,15 @@ func _input(event: InputEvent) -> void:
         # Emit camera values
         Globals.set_camera_x.emit(camera_x)
         Globals.set_camera_y.emit(camera_y)
+
+    if Input.is_key_pressed(KEY_1):
+        Globals.global_lod = Chunk.LOD.HIGH
+        Globals.set_lod.emit(Chunk.LOD.HIGH)
+
+    if Input.is_key_pressed(KEY_2):
+        Globals.global_lod = Chunk.LOD.MEDIUM
+        Globals.set_lod.emit(Chunk.LOD.MEDIUM)
+
+    if Input.is_key_pressed(KEY_3):
+        Globals.global_lod = Chunk.LOD.LOW
+        Globals.set_lod.emit(Chunk.LOD.LOW)

--- a/scripts/input_controller.gd
+++ b/scripts/input_controller.gd
@@ -22,15 +22,3 @@ func _input(event: InputEvent) -> void:
         # Emit camera values
         Globals.set_camera_x.emit(camera_x)
         Globals.set_camera_y.emit(camera_y)
-
-    if Input.is_key_pressed(KEY_1):
-        Globals.global_lod = Chunk.LOD.HIGH
-        Globals.set_lod.emit(Chunk.LOD.HIGH)
-
-    if Input.is_key_pressed(KEY_2):
-        Globals.global_lod = Chunk.LOD.MEDIUM
-        Globals.set_lod.emit(Chunk.LOD.MEDIUM)
-
-    if Input.is_key_pressed(KEY_3):
-        Globals.global_lod = Chunk.LOD.LOW
-        Globals.set_lod.emit(Chunk.LOD.LOW)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -7,7 +7,6 @@ class_name Player
 @export var fall_acceleration: float = 3
 
 var target_velocity := Vector3.ZERO
-var chunk_position := Vector3.ZERO
 
 
 func _init() -> void:
@@ -51,3 +50,6 @@ func _physics_process(delta: float) -> void:
 
     # Apply velocity
     move_and_slide()
+
+    # Broadcast position
+    Globals.player_xz.emit(Vector2(position.x, position.z))

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -51,33 +51,3 @@ func _physics_process(delta: float) -> void:
 
     # Apply velocity
     move_and_slide()
-    update_chunk_pos()
-
-# Emit signal when crossing chunk boundaries
-func update_chunk_pos() -> void:
-    # Update position within current chunk
-    chunk_position += get_position_delta()
-
-    # Calculate chunk boundaries using globals
-    var positive_bound: float = (Globals.chunk_size + Globals.chunk_boundary_tolerance)
-    var negative_bound: float = -Globals.chunk_boundary_tolerance
-
-    # X_POS
-    if chunk_position.x >= positive_bound:
-        chunk_position.x -= Globals.chunk_size
-        Globals.entered_new_chunk.emit(Globals.DIRECTION.X_POS)
-
-    # X_NEG
-    elif chunk_position.x < negative_bound:
-        chunk_position.x += Globals.chunk_size
-        Globals.entered_new_chunk.emit(Globals.DIRECTION.X_NEG)
-
-    # Z_POS
-    if chunk_position.z >= positive_bound:
-        chunk_position.z -= Globals.chunk_size
-        Globals.entered_new_chunk.emit(Globals.DIRECTION.Z_POS)
-
-    # Z_NEG
-    elif chunk_position.z < negative_bound:
-        chunk_position.z += Globals.chunk_size
-        Globals.entered_new_chunk.emit(Globals.DIRECTION.Z_NEG)

--- a/scripts/world_generator.gd
+++ b/scripts/world_generator.gd
@@ -5,13 +5,13 @@ class_name WorldGenerator
 @export var chunk_size: float
 @export var chunk_boundary_tolerance: float
 
-const chunk_scene = preload("res://prefabs/chunk.tscn")
+const chunk_scene: PackedScene = preload("res://prefabs/chunk.tscn")
 
 var world_chunks: ChunkGrid
 var world_size: Vector2i
 
 
-func _init() -> void:
+func _ready() -> void:
     # Initialize global world variables
     Globals.world_radius = world_radius
     Globals.chunk_size = chunk_size

--- a/scripts/world_generator.gd
+++ b/scripts/world_generator.gd
@@ -23,9 +23,6 @@ func _ready() -> void:
     Globals.high_lod_distance = high_lod_distance
     Globals.medium_lod_distance = medium_lod_distance
 
-    # Connect global signals
-    Globals.entered_new_chunk.connect(_on_entered_new_chunk)
-
     # Allocate chunk array
     var row_size: int = Globals.world_radius * 2
     world_size = Vector2i(row_size, row_size)
@@ -35,6 +32,3 @@ func _ready() -> void:
         chunk_scene,
         Vector2(chunk_size, chunk_size)
     )
-
-func _on_entered_new_chunk(direction: Globals.DIRECTION) -> void:
-    world_chunks.move(direction)

--- a/scripts/world_generator.gd
+++ b/scripts/world_generator.gd
@@ -5,6 +5,9 @@ class_name WorldGenerator
 @export var chunk_size: float
 @export var chunk_boundary_tolerance: float
 
+@export var high_lod_distance: float
+@export var medium_lod_distance: float
+
 const chunk_scene: PackedScene = preload("res://prefabs/chunk.tscn")
 
 var world_chunks: ChunkGrid
@@ -16,6 +19,9 @@ func _ready() -> void:
     Globals.world_radius = world_radius
     Globals.chunk_size = chunk_size
     Globals.chunk_boundary_tolerance = chunk_boundary_tolerance
+
+    Globals.high_lod_distance = high_lod_distance
+    Globals.medium_lod_distance = medium_lod_distance
 
     # Connect global signals
     Globals.entered_new_chunk.connect(_on_entered_new_chunk)


### PR DESCRIPTION
## PR Summary

PR Link: https://github.com/xwilson03/OpenWorldTest/pull/5
Issue Link: https://github.com/xwilson03/OpenWorldTest/issues/4

Closes #4 

## Description
Expands infinite world generator to encompass lower levels of detail for distant chunks.

## Changelog
### Major
- Changes Chunk prefab to instead include High, Medium, and Low LOD meshes/textures
- Adds LOD distance parameters to WorldGenerator script.
- Removes chunk position tracking in player script.
  - Broadcasts position to new signal Globals.player_xz instead
- Adds player position callback to ChunkGrid for handling infinite scroll
- Adds Chunk script for handling LOD per-chunk using player position
### Misc
- Increases max camera distance to 200 (from 50).
- Increases world radius to 20 (from 10).
